### PR TITLE
Move most data bindings to garfield db

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,10 @@
 
 Postgres backend for [odie](https://github.com/fsmi/odie-client).
 
+## Setup ##
+
+You'll need a running postgres instance with two databases called "garfield" and "fsmi".  
+(execute `createdb garfield` and `createdb fsmi` as your postgres user (or use the `-O` parameter) to create them.)
+
 Use `fill_data.py` to create all necessary schemas and tables in your local postgresql instance and to fill it with some sample data.
+If you want to set up the database but don't want any sample data to be created in there, use `create_schemas_and_tables.py`.

--- a/app.py
+++ b/app.py
@@ -8,7 +8,8 @@ from flask.ext.login import LoginManager
 from sqlalchemy.dialects import postgres
 
 app = Flask("odie")
-app.config['SQLALCHEMY_DATABASE_URI'] = 'postgres:///fsmi'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'postgres:///garfield'  # use garfield for everything by default
+app.config['SQLALCHEMY_BINDS'] = { 'fsmi': 'postgres:///fsmi' }  # we also need to access the fsmi db in some places, e.g. for user auth
 
 # TODO change me in production
 app.config['SECRET_KEY'] = 'supersikkrit'
@@ -23,8 +24,16 @@ login_manager.setup_app(app)
 # we set them here for proper reuse (and documentation purposes)
 odie_table_args = {'schema' : 'odie'}  # things specific to odie: saved carts
 documents_table_args = {'schema': 'documents'}
-acl_table_args = {'schema' : 'acl'}  # auth credentials
-public_table_args = {'schema' : 'public'}  # if we don't explicitly set this we can't create cross-schema aux tables
+
+# auth credentials
+acl_table_args = {
+    'schema' : 'acl',
+    'info': {'bind_key': 'fsmi'}
+}
+public_table_args = {
+    'schema' : 'public',  # if we don't explicitly set this we can't create cross-schema aux tables
+    'info': {'bind_key': 'fsmi'}
+}
 
 # sqlalchemy treats columns as nullable by default, which we don't want.
 Column = partial(db.Column, nullable=False)

--- a/create_schemas_and_tables.py
+++ b/create_schemas_and_tables.py
@@ -7,14 +7,15 @@ import app
 from sqlalchemy.schema import CreateSchema
 from app import db
 
-def createSchema(name):
+def createSchema(name, bind=None):
     try:
-        db.engine.execute(CreateSchema(name))
+        engine = db.get_engine(app.app, bind)
+        engine.execute(CreateSchema(name))
     except sqlalchemy.exc.ProgrammingError:
         # schema already exists... do nothing
         pass
 
-createSchema('acl')
+createSchema('acl', 'fsmi')
 createSchema('odie')
 createSchema('documents')
 


### PR DESCRIPTION
Document-related stuff is still in a separate `documents` schema, and carts (which are as of yet the only really odie-specific kind of data) are still in their own `odie` schema.