### PR TITLE
replace flask-restless with homegrown API generation

### DIFF
--- a/apigen.py
+++ b/apigen.py
@@ -1,0 +1,86 @@
+#! /usr/bin/env python3
+
+import json
+
+from app import app, db
+
+from functools import wraps
+from flask import request
+from flask.ext.login import login_required
+from jsonquery import jsonquery
+from marshmallow import ValidationError
+
+
+# Flask-login's @login_required decorator only supports all-or-nothing authentication,
+# however the orders API is only restricted for GET requests, hence this
+
+def login_required_for_methods(methods):
+    def _decorator(f):
+        login_f = login_required(f)
+        @wraps(f)
+        def wrapped_f(*args, **kw):
+            if request.method in methods:
+                return login_f(*args, **kw)
+            return f(*args, **kw)
+        return wrapped_f
+
+    return _decorator
+
+
+def instance_endpoint(url, serializer, model, methods=['GET'], auth_methods=[]):
+    """Creates an endpoint for single instance requests (e.g. /api/endpoint/1)
+
+    Currently only handles GET and DELETE requests.
+    url must specify a single URL parameter which is an int called `instance_id`.
+    """
+    @login_required_for_methods(auth_methods)
+    def route(instance_id):
+        if request.method == 'GET':
+            result = model.query.get(instance_id)
+            return serializer(result)
+        if request.method == 'DELETE':
+            obj = model.query.get(instance_id)
+            db.session.delete(obj)
+            db.session.commit()
+            return "ok"
+        raise NotImplementedError
+
+    # flask requires route names and routed urls to be unique. We can use that here.
+    route.__name__ = url
+    app.route(url, methods=methods)(route)
+
+
+def collection_endpoint(url, serdes, model, auth_methods=[]):
+    """Creates an endpoint for collection requests (e.g. /api/endpoint)
+
+    Currently only handles GET and POST requests.
+
+    serdes: dictionary of serializers/deserializers.
+            These keys also define permissible methods.
+    model: The db.Model to query. Mustn't be None for GET-enabled endpoints
+    """
+
+    @login_required_for_methods(auth_methods)
+    def route():
+        if request.method == 'POST':
+            try:
+                assert 'POST' in serdes, "deserializer missing"
+                obj = serdes['POST'](data=request.get_json(force=True))
+                db.session.add(obj)
+                db.session.commit()
+                return "ok"
+            except (ValueError, ValidationError):
+                return ("failed to parse json", 400, [])
+        if request.method == 'GET':
+            q = json.loads(request.args.get('q', '{}'))
+            query = jsonquery(db.session, model, q) if q else model.query
+            result = query.all()
+            assert 'GET' in serdes, "serializer missing"
+            return serdes['GET'](result)
+        raise NotImplementedError
+
+    # flask requires route names and routed urls to be unique. We can use that here.
+    route.__name__ = url
+    app.route(url, methods=serdes.keys())(route)
+
+

--- a/app.py
+++ b/app.py
@@ -1,9 +1,6 @@
 #! /usr/bin/env python3
 
 import config
-# extend query operators
-import jsonquery
-import jsonquery_operators
 
 from functools import partial
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,9 @@
 #! /usr/bin/env python3
 
 import config
+# extend query operators
+import jsonquery
+import jsonquery_operators
 
 from functools import partial
 

--- a/fill_data.py
+++ b/fill_data.py
@@ -53,6 +53,7 @@ docs = [
             Document(lectures=[lectures[6], lectures[7]], examinants=[profs[1]], date=time(2004, 10, 4), number_of_pages=1, document_type='oral'),
             Document(lectures=[lectures[4], lectures[3], lectures[2]], examinants=[profs[1], profs[0]], date=time(2004, 8, 2), number_of_pages=2, document_type='oral'),
             Document(lectures=[lectures[5], lectures[6], lectures[7]], examinants=[profs[3], profs[0], profs[2]], date=time(2000, 1, 1), number_of_pages=7, document_type='oral'),
+            Document(lectures=[lectures[5], lectures[6], lectures[7]], examinants=[profs[3], profs[0], profs[2]], date=time(2000, 2, 3), number_of_pages=7, document_type='oral')
        ]
 
 for d in docs:

--- a/fill_data.py
+++ b/fill_data.py
@@ -12,7 +12,7 @@ from app import db
 from models.documents import Lecture, Document, Examinant, Deposit
 from models.public import User
 from models.acl import Permission
-from models.odie import Order, OrderDocument
+from models.odie import Order
 
 from datetime import datetime as time
 
@@ -49,10 +49,10 @@ db.session.add(Deposit(price=10, name='Montgomery Montgomery', lectures=[lecture
 db.session.add(Deposit(price=5, name='Random J. Hacker', lectures=[lectures[1], lectures[2], lectures[7]]))
 
 docs = [
-            Document(lectures=[lectures[0], lectures[1], lectures[5]], examinants=[profs[3]], date=time(2010, 4, 1), number_of_pages=4, documentType='oral'),
-            Document(lectures=[lectures[6], lectures[7]], examinants=[profs[1]], date=time(2004, 10, 4), number_of_pages=1, documentType='oral'),
-            Document(lectures=[lectures[4], lectures[3], lectures[2]], examinants=[profs[1], profs[0]], date=time(2004, 8, 2), number_of_pages=2, documentType='oral'),
-            Document(lectures=[lectures[5], lectures[6], lectures[7]], examinants=[profs[3], profs[0], profs[2]], date=time(2000, 1, 1), number_of_pages=7, documentType='oral')
+            Document(lectures=[lectures[0], lectures[1], lectures[5]], examinants=[profs[3]], date=time(2010, 4, 1), number_of_pages=4, document_type='oral'),
+            Document(lectures=[lectures[6], lectures[7]], examinants=[profs[1]], date=time(2004, 10, 4), number_of_pages=1, document_type='oral'),
+            Document(lectures=[lectures[4], lectures[3], lectures[2]], examinants=[profs[1], profs[0]], date=time(2004, 8, 2), number_of_pages=2, document_type='oral'),
+            Document(lectures=[lectures[5], lectures[6], lectures[7]], examinants=[profs[3], profs[0], profs[2]], date=time(2000, 1, 1), number_of_pages=7, document_type='oral'),
        ]
 
 for d in docs:
@@ -65,21 +65,10 @@ for d in docs:
 # Order
 db.session.commit()
 
-c = Order(name='Hatsune Miku', creation_time=time(2009, 4, 2))
-db.session.add(c)
-db.session.add(OrderDocument(order=c, document_id=docs[0].id))
-db.session.add(OrderDocument(order=c, document_id=docs[3].id))
-c = Order(name='Megurine Luka', creation_time=time(2012, 10, 10))
-db.session.add(c)
-db.session.add(OrderDocument(order=c, document_id=docs[2].id))
-db.session.add(OrderDocument(order=c, document_id=docs[3].id))
-db.session.add(OrderDocument(order=c, document_id=docs[1].id))
-c = Order(name='Kagamine Rin', creation_time=time(2011, 1, 3))
-db.session.add(c)
-db.session.add(OrderDocument(order=c, document_id=docs[1].id))
-c = Order(name='Kagamine Len', creation_time=time(2014, 1, 2))
-db.session.add(c)
-db.session.add(OrderDocument(order=c, document_id=docs[1].id))
+db.session.add(Order(name='Hatsune Miku', document_ids=[1,4], creation_time=time(2009, 4, 2)))
+db.session.add(Order(name='Megurine Luka', document_ids=[4,3,2], creation_time=time(2012, 10, 10)))
+db.session.add(Order(name='Kagamine Rin', document_ids=[2], creation_time=time(2011, 1, 3)))
+db.session.add(Order(name='Kagamine Len', document_ids=[2], creation_time=time(2014, 1, 2)))
 
 
 

--- a/fill_data.py
+++ b/fill_data.py
@@ -12,7 +12,7 @@ from app import db
 from models.documents import Lecture, Document, Examinant, Deposit
 from models.public import User
 from models.acl import Permission
-from models.odie import Cart, CartDocument
+from models.odie import Order, OrderDocument
 
 from datetime import datetime as time
 
@@ -62,24 +62,24 @@ for d in docs:
 
 
 
-# Cart
+# Order
 db.session.commit()
 
-c = Cart(name='Hatsune Miku', creation_time=time(2009, 4, 2))
+c = Order(name='Hatsune Miku', creation_time=time(2009, 4, 2))
 db.session.add(c)
-db.session.add(CartDocument(cart=c, document_id=docs[0].id))
-db.session.add(CartDocument(cart=c, document_id=docs[3].id))
-c = Cart(name='Megurine Luka', creation_time=time(2012, 10, 10))
+db.session.add(OrderDocument(order=c, document_id=docs[0].id))
+db.session.add(OrderDocument(order=c, document_id=docs[3].id))
+c = Order(name='Megurine Luka', creation_time=time(2012, 10, 10))
 db.session.add(c)
-db.session.add(CartDocument(cart=c, document_id=docs[2].id))
-db.session.add(CartDocument(cart=c, document_id=docs[3].id))
-db.session.add(CartDocument(cart=c, document_id=docs[1].id))
-c = Cart(name='Kagamine Rin', creation_time=time(2011, 1, 3))
+db.session.add(OrderDocument(order=c, document_id=docs[2].id))
+db.session.add(OrderDocument(order=c, document_id=docs[3].id))
+db.session.add(OrderDocument(order=c, document_id=docs[1].id))
+c = Order(name='Kagamine Rin', creation_time=time(2011, 1, 3))
 db.session.add(c)
-db.session.add(CartDocument(cart=c, document_id=docs[1].id))
-c = Cart(name='Kagamine Len', creation_time=time(2014, 1, 2))
+db.session.add(OrderDocument(order=c, document_id=docs[1].id))
+c = Order(name='Kagamine Len', creation_time=time(2014, 1, 2))
 db.session.add(c)
-db.session.add(CartDocument(cart=c, document_id=docs[1].id))
+db.session.add(OrderDocument(order=c, document_id=docs[1].id))
 
 
 

--- a/models/documents.py
+++ b/models/documents.py
@@ -17,6 +17,9 @@ class Lecture(db.Model):
     subject = app.Column(postgres.ENUM('mathematics', 'computer science', 'both', name='subject'))
     comment = app.Column(db.String(256), default='')
 
+    def __str__(self):
+        return self.name
+
 
 lectureDocs = db.Table('lecture_docs',
         app.Column('lecture_id', db.Integer, db.ForeignKey('documents.lectures.id')),
@@ -43,8 +46,16 @@ class Document(db.Model):
     number_of_pages = app.Column(db.Integer)
     solution = app.Column(postgres.ENUM('official', 'inofficial', 'none', name='solution'), default='none')
     comment = app.Column(db.String(80), default='')
-    documentType = app.Column(postgres.ENUM('oral', 'written', 'oral reexam', name='type'))
+    document_type = app.Column(postgres.ENUM('oral', 'written', 'oral reexam', name='type'))
     file_id = app.Column(db.String(256), nullable=True)  # usually sha256sum of file
+
+    @property
+    def examinants_names(self):
+        return [ex.name for ex in self.examinants]
+
+    @property
+    def examinants_ids(self):
+        return [ex.id for ex in self.examinants]
 
 
 class Examinant(db.Model):
@@ -53,6 +64,9 @@ class Examinant(db.Model):
 
     id = app.Column(db.Integer, primary_key=True)
     name = app.Column(db.String(80))
+
+    def __str__(self):
+        return self.name
 
 
 depositLectures = db.Table('deposit_lectures',

--- a/models/odie.py
+++ b/models/odie.py
@@ -8,21 +8,21 @@ from app import db
 from sqlalchemy.dialects import postgres
 
 
-class CartDocument(db.Model):
-    __tablename__ = 'cart_documents'
+class OrderDocument(db.Model):
+    __tablename__ = 'order_documents'
     __table_args__ = config.odie_table_args
 
-    cart_id = app.Column(db.Integer, db.ForeignKey('odie.carts.id'), primary_key=True)
-    cart = db.relationship('Cart', backref=db.backref('items'))
+    order_id = app.Column(db.Integer, db.ForeignKey('odie.orders.id'), primary_key=True)
+    order = db.relationship('Order', backref=db.backref('items'))
     document_id = app.Column(db.ForeignKey('documents.documents.id'), primary_key=True)
 
 
-class Cart(db.Model):
-    __tablename__ = 'carts'
+class Order(db.Model):
+    __tablename__ = 'orders'
     __table_args__ = config.odie_table_args
 
     id = app.Column(db.Integer, primary_key=True)
     name = app.Column(db.String(256))
     creation_time = app.Column(postgres.DATE, default=db.func.now())
-    documents = db.relationship('Document', secondary='odie.cart_documents')
+    documents = db.relationship('Document', secondary='odie.order_documents')
 

--- a/models/odie.py
+++ b/models/odie.py
@@ -2,19 +2,22 @@
 
 import app
 import config
-import models.documents
 
 from app import db
 from sqlalchemy.dialects import postgres
+from datetime import datetime as time
 
+from models.documents import Document
 
 class OrderDocument(db.Model):
     __tablename__ = 'order_documents'
     __table_args__ = config.odie_table_args
 
     order_id = app.Column(db.Integer, db.ForeignKey('odie.orders.id'), primary_key=True)
-    order = db.relationship('Order', backref=db.backref('items'))
+    order = db.relationship('Order', backref=db.backref('items', cascade='all'))
     document_id = app.Column(db.ForeignKey('documents.documents.id'), primary_key=True)
+    document = db.relationship('Document')
+    index = app.Column(db.Integer, primary_key=True)
 
 
 class Order(db.Model):
@@ -24,5 +27,14 @@ class Order(db.Model):
     id = app.Column(db.Integer, primary_key=True)
     name = app.Column(db.String(256))
     creation_time = app.Column(postgres.DATE, default=db.func.now())
-    documents = db.relationship('Document', secondary='odie.order_documents')
+
+    def __init__(self, name, document_ids, creation_time=None):
+        self.name = name
+        self.creation_time = creation_time
+        for idx, doc in enumerate(document_ids):
+            OrderDocument(order=self, document_id=doc, index=idx)
+
+    @property
+    def documents(self):
+        return [item.document for item in sorted(self.items, key=lambda x: x.index)]
 

--- a/odie.py
+++ b/odie.py
@@ -3,32 +3,7 @@
 import app
 import routes
 
-from flask.ext.restless import APIManager, ProcessingException
-from flask.ext.login import current_user
+from app import app
 
-from app import app, db
-from models import documents
-from models import odie
-
-
-# Why is this here if we're also using flask-login's login_required decorator in routes.py?
-# Because its API doesn't fit use as a flask-restless preprocessor, which we need to
-# protect auto-generated api endpoints. This means that some endpoints will generate differing
-# 'not authorized' messages when queried while not logged in, but that's okay.
-def auth_preproc(**kw):
-    if not current_user.is_authenticated():
-        raise ProcessingException(description='Not Authorized', code=401)
-
-manager = APIManager(app, flask_sqlalchemy_db=db)
-manager.create_api(documents.Lecture,
-        exclude_columns=['documents'])
-manager.create_api(documents.Document,
-        exclude_columns=['legacy_id', 'file_id'])
-manager.create_api(documents.Examinant)
-manager.create_api(
-        documents.Deposit,
-        methods=['GET', 'POST'],
-        preprocessors={'GET_SINGLE': [auth_preproc], 'GET_MANY': [auth_preproc], 'POST': [auth_preproc]})
-manager.create_api(odie.Cart, methods=['POST', 'GET'])
-
-app.run()
+if __name__ == '__main__':
+    app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jsonquery
 Flask-SQLAlchemy
 Flask-Login
+marshmallow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Flask-Restless
+jsonquery
 Flask-SQLAlchemy
 Flask-Login

--- a/routes.py
+++ b/routes.py
@@ -3,40 +3,78 @@
 import app
 import json
 
-from functools import wraps
+from flask import request, jsonify
+from flask.ext.login import login_user, logout_user, current_user, login_required
 
 from app import app, db
-from flask import request, jsonify
-from flask.ext.restless import ProcessingException
-from flask.ext.login import login_user, logout_user, current_user, login_required
+from apigen import login_required_for_methods, collection_endpoint, instance_endpoint
+from models.documents import Lecture, Deposit, Document, Examinant
+from models.odie import Order
 from models.public import User
+from serialization_schemas import OrderLoadSchema, OrderDumpSchema, LectureSchema, LectureDocumentsSchema, DocumentSchema, ExaminantSchema
 
 
 @app.route('/api/login', methods=['POST'])
 def login():
-    if current_user.is_authenticated():
-        return jsonify({
-                'user': current_user.username,
-                'firstName': current_user.first_name,
-                'lastName': current_user.last_name
-            })
-    try:
-        json = request.get_json(force=True)  # ignore Content-Type
-        user = User.authenticate(json['username'], json['password'])
-        if user:
+    if not current_user.is_authenticated():
+        try:
+            json = request.get_json(force=True)  # ignore Content-Type
+            user = User.authenticate(json['username'], json['password'])
+            if not user:
+                return ("invalid login", 401, [])
             login_user(user)
-            return jsonify({
-                    'user': user.username,
-                    'firstName': user.first_name,
-                    'lastName': user.last_name
-                })
-        raise ProcessingException(description="invalid login", code=401)
-    except KeyError:
-        raise ProcessingException(description="malformed request", code=400)
+        except KeyError:
+            return ("malformed request", 400, [])
+    return jsonify({
+            'user': current_user.username,
+            'firstName': current_user.first_name,
+            'lastName': current_user.last_name
+        })
 
 
 @app.route('/api/logout', methods=['POST'])
 @login_required
 def logout():
     logout_user()
-    return ("ok", 200, [])
+    return "ok"
+
+
+def dumpSchema(schema, many=False):
+    return lambda obj: schema().dumps(obj, many).data
+
+
+collection_endpoint(
+        url='/api/orders',
+        serdes={
+            'GET': dumpSchema(OrderDumpSchema, many=True),
+            'POST': OrderLoadSchema().make_object
+        },
+        model=Order,
+        auth_methods=['GET'])
+
+instance_endpoint(
+        url='/api/orders/<int:instance_id>',
+        serializer= dumpSchema(OrderDumpSchema),
+        model=Order,
+        methods=['GET', 'DELETE'],
+        auth_methods=['GET', 'DELETE'])
+
+collection_endpoint(
+        url='/api/lectures',
+        serdes={'GET': dumpSchema(LectureSchema, many=True)},
+        model=Lecture)
+
+instance_endpoint(
+        url='/api/lectures/<int:instance_id>',
+        serializer=dumpSchema(LectureDocumentsSchema),
+        model=Lecture)
+
+collection_endpoint(
+        url='/api/documents',
+        serdes={'GET': dumpSchema(DocumentSchema, many=True)},
+        model=Document)
+
+collection_endpoint(
+        url='/api/examinants',
+        serdes={'GET': dumpSchema(ExaminantSchema, many=True)},
+        model=Examinant)

--- a/routes.py
+++ b/routes.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python3
 
 import app
-import models.public
+import json
 
 from functools import wraps
 
-from app import app
-from flask import request
+from app import app, db
+from flask import request, jsonify
 from flask.ext.restless import ProcessingException
 from flask.ext.login import login_user, logout_user, current_user, login_required
 from models.public import User
@@ -14,15 +14,26 @@ from models.public import User
 
 @app.route('/api/login', methods=['POST'])
 def login():
+    if current_user.is_authenticated():
+        return jsonify({
+                'user': current_user.username,
+                'firstName': current_user.first_name,
+                'lastName': current_user.last_name
+            })
     try:
         json = request.get_json(force=True)  # ignore Content-Type
         user = User.authenticate(json['username'], json['password'])
         if user:
             login_user(user)
-            return ("ok", 200, [])
+            return jsonify({
+                    'user': user.username,
+                    'firstName': user.first_name,
+                    'lastName': user.last_name
+                })
         raise ProcessingException(description="invalid login", code=401)
     except KeyError:
         raise ProcessingException(description="malformed request", code=400)
+
 
 @app.route('/api/logout', methods=['POST'])
 @login_required

--- a/serialization_schemas.py
+++ b/serialization_schemas.py
@@ -1,0 +1,53 @@
+#! /usr/bin/env python3
+
+from datetime import datetime as time
+from marshmallow import Schema, fields
+
+from models.documents import Document
+from models.odie import Order
+
+
+class IdSchema(Schema):
+    id = fields.Int()
+
+class DocumentSchema(IdSchema):
+    lectures = fields.List(fields.Str())
+    examinants = fields.List(fields.Int(), attribute='examinants_ids')
+    date = fields.Date()
+    number_of_pages = fields.Int()
+    solution = fields.Str()
+    comment = fields.Str()
+    documentType = fields.Str(attribute='document_type')
+
+
+class ExaminantSchema(IdSchema):
+    name = fields.Str()
+
+
+class OrderLoadSchema(Schema):
+    name = fields.Str(required=True)
+    creation_time = fields.Date()
+    # list of document ids
+    documents = fields.List(fields.Int(), required=True)
+
+    def make_object(self, data):
+        return Order(name=data['name'],
+                     creation_time=time.now(),
+                     document_ids=data['documents'])
+
+
+class OrderDumpSchema(OrderLoadSchema):
+    documents = fields.List(fields.Nested(DocumentSchema))
+
+
+class LectureSchema(IdSchema):
+    name = fields.Str()
+    aliases = fields.List(fields.Str())
+    subject = fields.Str()
+    comment = fields.Str()
+
+class LectureDocumentsSchema(LectureSchema):
+    documents = fields.List(fields.Nested(DocumentSchema))
+
+
+


### PR DESCRIPTION
Featuring jsonquery and marshmallow. I'll end up putting the schemas in their own module though.
requests to try out:
```
# Orders with name matching 'miku'
curl 'http://127.0.0.1:5000/api/orders?q=\{"operator":"ilike","value":"%miku%","column":"name"\}' -b session=eyJfZnJlc2giOnRydWUsIl9pZCI6IjE4MTcwN2Q5YzcyZWM0OTc1MzM1ZTZlMGFlNWRiOWE0IiwidXNlcl9pZCI6IjEifQ.CDjfoQ.pjJjGNLIlep3gG3d7vg7YEOpWbg
# Submit test order
curl http://127.0.0.1:5000/api/orders -d '{"documents":[3],"name":"TEST"}'
# View it
curl 'http://127.0.0.1:5000/api/orders/5' -b session=eyJfZnJlc2giOnRydWUsIl9pZCI6IjE4MTcwN2Q5YzcyZWM0OTc1MzM1ZTZlMGFlNWRiOWE0IiwidXNlcl9pZCI6IjEifQ.CDjfoQ.pjJjGNLIlep3gG3d7vg7YEOpWbg
# delete it again
curl 'http://127.0.0.1:5000/api/orders/5' -X DELETE -b session=eyJfZnJlc2giOnRydWUsIl9pZCI6IjE4MTcwN2Q5YzcyZWM0OTc1MzM1ZTZlMGFlNWRiOWE0IiwidXNlcl9pZCI6IjEifQ.CDjfoQ.pjJjGNLIlep3gG3d7vg7YEOpWbg
```