### PR TITLE
integrate accounting, add rest of endpoints

### DIFF
--- a/apigen.py
+++ b/apigen.py
@@ -12,23 +12,7 @@ from jsonquery import jsonquery
 from marshmallow import ValidationError
 
 
-# Flask-login's @login_required decorator only supports all-or-nothing authentication,
-# however the orders API is only restricted for GET requests, hence this
-
-def login_required_for_methods(methods):
-    def _decorator(f):
-        login_f = login_required(f)
-        @wraps(f)
-        def wrapped_f(*args, **kw):
-            if request.method in methods:
-                return login_f(*args, **kw)
-            return f(*args, **kw)
-        return wrapped_f
-
-    return _decorator
-
-
-def accepts_json(schema):
+def deserialize(schema):
     def _decorator(f):
         @wraps(f)
         def wrapped_f(*args, **kwargs):
@@ -85,7 +69,7 @@ def endpoint(model, schemas={}, methods=[], callback=lambda *_1, **_2: None):
         db.session.commit()
         return {}
 
-    @accepts_json(schemas['POST'] if 'POST' in schemas else None)
+    @deserialize(schemas['POST'] if 'POST' in schemas else None)
     def handle_post(data=None):
         if model:
             db.session.add(data)

--- a/default_config.py
+++ b/default_config.py
@@ -47,4 +47,4 @@ FS_CONFIG = {
         'Sprechstundenkasse Mathematik',
     ],
 }
-GARFIELD_ACCOUNTING = True
+GARFIELD_ACCOUNTING = False

--- a/routes.py
+++ b/routes.py
@@ -86,7 +86,7 @@ def print_documents(data):
 @app.route('/api/log_erroneous_sale', methods=['POST'])
 @login_required
 @apigen.deserialize(schemas.ErroneousSaleLoadSchema)
-def accept_erroneous_sale():
+def accept_erroneous_sale(data):
     accounting.log_erroneous_sale(data['amount'], current_user, data['cash_box'])
     db.session.commit()
     return {}

--- a/routes.py
+++ b/routes.py
@@ -103,13 +103,14 @@ def log_deposit_return(data):
     return {}
 
 
-app.route('/api/donation', methods=['POST'])(
-login_required(
-apigen.endpoint(
-        model=None,
-        schemas={'POST': schemas.DonationLoadSchema},
-        callback=lambda obj: accounting.log_donation(obj['amount'], obj['cash_box']))
-))
+@app.route('/api/donation', methods=['POST'])
+@login_required
+@apigen.deserialize(schemas.DonationLoadSchema)
+def log_donation(data):
+    accounting.log_donation(data['amount'], data['cash_box'])
+    db.session.commit()
+    return {}
+
 
 app.route('/api/orders', methods=['GET'])(
 login_required(
@@ -134,7 +135,7 @@ login_required(
 apigen.endpoint(
         schemas={'GET': schemas.OrderDumpSchema},
         model=Order,
-        methods=['DELETE'])
+        allow_delete=True)
 ))
 
 

--- a/routes.py
+++ b/routes.py
@@ -110,7 +110,7 @@ def log_deposit_return():
     if errors:
         raise ClientError(*errors)
     dep = Deposit.query.get(obj['id'])
-    db.session.delete(obj)
+    db.session.delete(dep)
     accounting.log_deposit_return(dep, current_user, obj['cash_box'])
     db.session.commit()
     return {}

--- a/serialization_schemas.py
+++ b/serialization_schemas.py
@@ -58,8 +58,11 @@ class OrderLoadSchema(Schema):
     document_ids = fields.List(fields.Int(), required=True)
 
     def make_object(self, data):
-        return Order(name=data['name'],
-                     document_ids=data['document_ids'])
+        try:
+            return Order(name=data['name'],
+                         document_ids=data['document_ids'])
+        except KeyError:
+            raise ClientError('invalid json. name or document_ids missing?')
 
 
 class OrderDumpSchema(IdSchema):

--- a/serialization_schemas.py
+++ b/serialization_schemas.py
@@ -42,7 +42,7 @@ class ExaminantSchema(IdSchema):
     name = fields.Str()
 
 
-class OrderLoadSchema(IdSchema):
+class OrderLoadSchema(Schema):
     name = fields.Str(required=True)
     document_ids = fields.List(fields.Int(), required=True)
 

--- a/serialization_schemas.py
+++ b/serialization_schemas.py
@@ -24,6 +24,17 @@ class IdSchema(Schema):
     id = fields.Int(required=True)
 
 
+class UserLoadSchema(Schema):
+    username = fields.Str(required=True)
+    password = fields.Str(required=True)
+
+
+class UserDumpSchema(Schema):
+    username = fields.Str()
+    first_name = fields.Str()
+    last_name = fields.Str()
+
+
 class DocumentSchema(IdSchema):
     lectures = fields.List(fields.Nested(IdSchema))
     examinants = fields.List(fields.Nested(IdSchema))

--- a/serialization_schemas.py
+++ b/serialization_schemas.py
@@ -62,7 +62,7 @@ class OrderLoadSchema(Schema):
             return Order(name=data['name'],
                          document_ids=data['document_ids'])
         except KeyError:
-            raise ClientError('invalid json. name or document_ids missing?')
+            return None
 
 
 class OrderDumpSchema(IdSchema):

--- a/serialization_schemas.py
+++ b/serialization_schemas.py
@@ -52,7 +52,7 @@ class OrderLoadSchema(Schema):
 
 
 class OrderDumpSchema(IdSchema):
-    name = fields.Str(required=True)
+    name = fields.Str()
     documents = fields.List(fields.Nested(DocumentSchema))
 
 

--- a/serialization_schemas.py
+++ b/serialization_schemas.py
@@ -18,7 +18,7 @@ def serialize(data, schema, many=False):
 
 
 class IdSchema(Schema):
-    id = fields.Int()
+    id = fields.Int(required=True)
 
 
 class DocumentSchema(IdSchema):
@@ -60,10 +60,14 @@ class LectureSchema(IdSchema):
     comment = fields.Str()
 
 
-class DepositSchema(IdSchema):
+class DepositDumpSchema(IdSchema):
     price = fields.Int()
     name = fields.Str()
     lectures = fields.List(fields.Str())
+
+
+class DepositLoadSchema(IdSchema):
+    cash_box = fields.Str(required=True, validate=lambda s: s in config.FS_CONFIG['CASH_BOXES'])
 
 
 class PrintJobLoadSchema(Schema):

--- a/serialization_schemas.py
+++ b/serialization_schemas.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 
 from datetime import datetime as time
+from functools import partial
 from marshmallow import Schema, fields
 
 import config
@@ -8,6 +9,8 @@ from models.documents import Document
 from models.odie import Order
 from odie import ClientError
 
+CashBoxField = partial(fields.Str, required=True, validate=lambda s: s in config.FS_CONFIG['CASH_BOXES'])
+PrinterField = partial(fields.Str, required=True, validate=lambda s: s in config.FS_CONFIG['PRINTERS'])
 
 def serialize(data, schema, many=False):
     res = schema().dump(data, many)
@@ -67,22 +70,22 @@ class DepositDumpSchema(IdSchema):
 
 
 class DepositLoadSchema(IdSchema):
-    cash_box = fields.Str(required=True, validate=lambda s: s in config.FS_CONFIG['CASH_BOXES'])
+    cash_box = CashBoxField()
 
 
 class PrintJobLoadSchema(Schema):
     coverText = fields.Str(required=True)
     document_ids = fields.List(fields.Int(), required=True)
     deposit_count = fields.Int(required=True)
-    printer = fields.Str(required=True, validate=lambda s: s in config.FS_CONFIG['PRINTERS'])
+    printer = PrinterField()
 
 
 class DonationLoadSchema(Schema):
     amount = fields.Int(required=True, validate=lambda i: i > 0)
-    cash_box = fields.Str(required=True, validate=lambda s: s in config.FS_CONFIG['CASH_BOXES'])
+    cash_box = CashBoxField()
 
 
 class ErroneousSaleLoadSchema(Schema):
     amount = fields.Int(required=True, validate=lambda i: i > 0)
-    cash_box = fields.Str(required=True, validate=lambda s: s in config.FS_CONFIG['CASH_BOXES'])
+    cash_box = CashBoxField()
 

--- a/serialization_schemas.py
+++ b/serialization_schemas.py
@@ -72,3 +72,13 @@ class PrintJobLoadSchema(Schema):
     deposit_count = fields.Int(required=True)
     printer = fields.Str(required=True, validate=lambda s: s in config.FS_CONFIG['PRINTERS'])
 
+
+class DonationLoadSchema(Schema):
+    amount = fields.Int(required=True, validate=lambda i: i > 0)
+    cash_box = fields.Str(required=True, validate=lambda s: s in config.FS_CONFIG['CASH_BOXES'])
+
+
+class ErroneousSaleLoadSchema(Schema):
+    amount = fields.Int(required=True, validate=lambda i: i > 0)
+    cash_box = fields.Str(required=True, validate=lambda s: s in config.FS_CONFIG['CASH_BOXES'])
+

--- a/serialization_schemas.py
+++ b/serialization_schemas.py
@@ -48,7 +48,8 @@ class OrderLoadSchema(IdSchema):
                      document_ids=data['document_ids'])
 
 
-class OrderDumpSchema(OrderLoadSchema):
+class OrderDumpSchema(IdSchema):
+    name = fields.Str(required=True)
     documents = fields.List(fields.Nested(DocumentSchema))
 
 
@@ -68,6 +69,6 @@ class DepositSchema(IdSchema):
 class PrintJobLoadSchema(Schema):
     coverText = fields.Str(required=True)
     document_ids = fields.List(fields.Int(), required=True)
-    depositCount = fields.Int(required=True)
+    deposit_count = fields.Int(required=True)
     printer = fields.Str(required=True, validate=lambda s: s in config.FS_CONFIG['PRINTERS'])
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -96,9 +96,9 @@ class APITest(OdieTestCase):
         res = self.login(self.VALID_USER, self.VALID_PASS)
         assert res.status_code == 200
 
-    def test_login_no_get(self):
+    def test_login_no_get_unauthenticated(self):
         res = self.app.get('/api/login')
-        assert res.status_code == 405
+        assert res.status_code == 401
 
     def test_login_logout(self):
         def is_logged_in():
@@ -108,6 +108,15 @@ class APITest(OdieTestCase):
         assert is_logged_in()
         self.logout()
         assert not is_logged_in()
+
+    def test_login_get_authenticated(self):
+        self.login()
+        res = self.app.get('/api/login')
+        assert res.status_code == 200
+        data = self.fromJsonResponse(res)
+        assert 'username' in data
+        assert 'first_name' in data
+        assert 'last_name' in data
 
     ## tests for authenticated api ##
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -25,6 +25,11 @@ class APITest(OdieTestCase):
             'id': 1,
         }
 
+    VALID_ACCOUNTING_CORR = {
+            'cash_box': CASH_BOX,
+            'amount': 42,
+        }
+
     def login(self, user=VALID_USER, password=VALID_PASS):
         return self.app.post('/api/login', data=json.dumps({
                 'username': user,
@@ -179,6 +184,25 @@ class APITest(OdieTestCase):
         assert res.status_code == 200
         for deposit in self.fromJsonResponse(self.app.get('/api/deposits')):
             assert deposit['id'] != id_to_delete
+
+    def test_no_donation_unauthenticated(self):
+        res = self.app.post('/api/donation', data=json.dumps(self.VALID_ACCOUNTING_CORR))
+        assert res.status_code == 401
+
+    def test_donation(self):
+        self.login()
+        res = self.app.post('/api/donation', data=json.dumps(self.VALID_ACCOUNTING_CORR))
+        assert res.status_code == 200
+
+    def test_no_log_erroneous_sale_unauthenticated(self):
+        res = self.app.post('/api/log_erroneous_sale', data=json.dumps(self.VALID_ACCOUNTING_CORR))
+        assert res.status_code == 401
+
+    def test_log_erroneous_sale(self):
+        self.login()
+        res = self.app.post('/api/log_erroneous_sale', data=json.dumps(self.VALID_ACCOUNTING_CORR))
+        assert res.status_code == 200
+
 
 
 if __name__ == '__main__':

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -85,7 +85,7 @@ class APITest(OdieTestCase):
     ## login tests ##
 
     def test_malformed_login(self):
-        res = self.app.post('/api/login', data=json.dumps({'user':self.VALID_USER}))
+        res = self.app.post('/api/login', data=json.dumps({'username':self.VALID_USER}))
         assert res.status_code == 400
 
     def test_invalid_login(self):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -10,13 +10,19 @@ from test.harness import OdieTestCase
 class APITest(OdieTestCase):
     VALID_USER = 'guybrush'
     VALID_PASS = 'arrrrr'
+    CASH_BOX = 'Sprechstundenkasse Informatik'
 
     VALID_PRINTJOB = {
             'coverText': 'Klausuren',
             'document_ids': [1,2,2],
             'deposit_count': 1,
             'printer': 'external',
-            'cash_box': 'Sprechstundenkasse Informatik',
+            'cash_box': CASH_BOX,
+        }
+
+    VALID_DEPOSIT_RETURN = {
+            'cash_box': CASH_BOX,
+            'id': 1,
         }
 
     def login(self, user=VALID_USER, password=VALID_PASS):
@@ -156,8 +162,8 @@ class APITest(OdieTestCase):
         res = self.app.get('/api/deposits')
         assert res.status_code == 401
 
-    def test_deposits_no_delete_unauthenticated(self):
-        res = self.app.delete('/api/deposits/1')
+    def test_deposits_no_return_unauthenticated(self):
+        res = self.app.post('/api/log_deposit_return', data=json.dumps(self.VALID_DEPOSIT_RETURN))
         assert res.status_code == 401
 
     def test_deposits_state(self):
@@ -167,7 +173,9 @@ class APITest(OdieTestCase):
         deposits = self.fromJsonResponse(res)
         assert isinstance(deposits, list)
         id_to_delete = random.choice(deposits)['id']
-        res = self.app.delete('/api/deposits/' + str(id_to_delete))
+        data = self.VALID_DEPOSIT_RETURN
+        data['id'] = id_to_delete
+        res = self.app.post('/api/log_deposit_return', data=json.dumps(data))
         assert res.status_code == 200
         for deposit in self.fromJsonResponse(self.app.get('/api/deposits')):
             assert deposit['id'] != id_to_delete

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -14,8 +14,9 @@ class APITest(OdieTestCase):
     VALID_PRINTJOB = {
             'coverText': 'Klausuren',
             'document_ids': [1,2,2],
-            'depositCount': 1,
-            'printer': 'external'
+            'deposit_count': 1,
+            'printer': 'external',
+            'cash_box': 'Sprechstundenkasse Informatik',
         }
 
     def login(self, user=VALID_USER, password=VALID_PASS):


### PR DESCRIPTION
This obviously depends on #24, so disregard the diff for `accounting.py` and `default_config.py`

* Merge API endpoint generators
* define endpoints for donations, logging of erroneous copies and returned deposits
* unify casing in serialization schemas to "python_casing"

TODO:
tests for new endpoints
also, fix tests for existing endpoints