### PR TITLE
Expose new printer names to clients

### DIFF
--- a/default_config.py
+++ b/default_config.py
@@ -46,8 +46,8 @@ FS_CONFIG = {
     'DEPOSIT_PRICE': 500,  # in cents
     'PRICE_PER_PAGE': 3,   # in cents
     'PRINTERS': [
-        'emergency',  # ATIS
-        'external',   # print for external customer
+        'ATIS',
+        'FSI',
     ],
     'CASH_BOXES': [
         'Sprechstundenkasse Informatik',

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -22,7 +22,7 @@ class APITest(OdieTestCase):
             'cover_text': 'Klausuren',
             'document_ids': [1,2,2],
             'deposit_count': 1,
-            'printer': 'external',
+            'printer': 'FSI',
             'cash_box': CASH_BOX,
         }
 


### PR DESCRIPTION
These names should be good enough for the client to just add '-Drucker' and show it to users