### PR TITLE
Use pids for barcode scanner ID uniqueness instead of Thread.ident

### DIFF
--- a/barcode/barcode.py
+++ b/barcode/barcode.py
@@ -10,7 +10,6 @@ import os
 import subprocess
 import socket
 import tempfile
-import threading
 
 from api_utils import document_path
 from db.documents import Document
@@ -117,7 +116,7 @@ class BarcodeScanner(object):
     Luckily the server's pretty resilient against hijinks.
     """
     def __init__(self, host, port, username):
-        username = ('%s_(Odie_%s)' % (username.replace(' ', '_'), str(threading.current_thread().ident))).encode('utf-8')
+        username = ('%s_(Odie_%s)' % (username.replace(' ', '_'), str(os.getpid()))).encode('utf-8')
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.settimeout(5)
         self.sock.connect((host, port))


### PR DESCRIPTION
Turns out Thread.ident is essentially id(Thread), which is unique within
a process and between processes if they don't share ASLR seeds, but our
production setup is a forking server, so the flask worker thread on
different worker processes will end up with the same thread ident.

Why doesn't Thread.ident simply use the thread's system id?