### PR TITLE
Remove 'both' from subject ENUM

### DIFF
--- a/admin/admin.py
+++ b/admin/admin.py
@@ -240,7 +240,6 @@ class LectureView(AuthModelView):
     subject_labels = {
         'computer science': 'Informatik',
         'mathematics': 'Mathematik',
-        'both': 'Beides',
         'other': 'Anderes (Ergänzungsfach)',
     }
     column_formatters = {

--- a/db/documents.py
+++ b/db/documents.py
@@ -14,7 +14,7 @@ class Lecture(sqla.Model):
     id = Column(sqla.Integer, primary_key=True)
     name = Column(sqla.String)
     aliases = Column(postgres.ARRAY(sqla.String), server_default='{}')
-    subject = Column(sqla.Enum('mathematics', 'computer science', 'both', 'other', name='subject', inherit_schema=True))
+    subject = Column(sqla.Enum('mathematics', 'computer science', 'other', name='subject', inherit_schema=True))
     comment = Column(sqla.String, server_default='')
     validated = Column(sqla.Boolean)
 

--- a/routes/documents.py
+++ b/routes/documents.py
@@ -103,7 +103,7 @@ class DocumentLoadSchema(Schema):  # used by student document submission
     date = fields.Date(required=True)
     document_type = fields.Str(required=True, validate=OneOf(['oral', 'oral reexam']))
     student_name = fields.Str(required=True)
-    subject = fields.Str(required=True, validate=OneOf(['computer science', 'mathematics', 'both', 'other']))
+    subject = fields.Str(required=True, validate=OneOf(['computer science', 'mathematics', 'other']))
 
 
 def _allowed_file(filename):

--- a/scripts/fill_data.py
+++ b/scripts/fill_data.py
@@ -24,7 +24,7 @@ import create_schemas_and_tables
 
 def fill():
     lectures = [
-            Lecture(name='Fortgeschrittenes Nichtstun', aliases=['Ugh'], subject='both', validated=True),
+            Lecture(name='Fortgeschrittenes Nichtstun', aliases=['Ugh'], subject='other', validated=True),
             Lecture(name='Moderne Programmierumgebungen am Beispiel von .SEXY', aliases=['.SEXY'], subject='computer science', validated=True),
             Lecture(name='"Advanced" Operating Systems', aliases=['Stupid Operating Systems'], subject='computer science', validated=True),
             Lecture(name='Einführung in die Kozuch-Theorie', aliases=[], subject='mathematics', validated=True),

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -321,7 +321,7 @@ class APITest(OdieTestCase):
                 'lectures': [
                     "Fortgeschrittenes Nichtstun",
                 ],
-                'subject': 'both',
+                'subject': 'computer science',
                 'examinants': ["Anon Ymous"],
                 'date': '2010-01-01T00:00:00',
                 'document_type': 'oral',


### PR DESCRIPTION
It's highly unlikely we'll ever need it, as the only lecture that comes
to mind is linear algebra, for which we sell math exams and still want
to differentiate between third-attempt-transcripts of math and CS
students.