### PR TITLE
endpoint: Only use query factories

### DIFF
--- a/api_utils.py
+++ b/api_utils.py
@@ -137,7 +137,7 @@ def api_route(url, *args, **kwargs):
 ROUTE_ID = 0
 
 
-def endpoint(query, schemas=None, allow_delete=False, paginate_many=True):
+def endpoint(query_fn, schemas=None, allow_delete=False, paginate_many=True):
     """Creates and returns an API endpoint handler
 
     Can create both SINGLE-style and MANY-style endpoints. The generated route simply
@@ -148,7 +148,7 @@ def endpoint(query, schemas=None, allow_delete=False, paginate_many=True):
 
     schemas: dictionary of {<method>: serializer/deserializer}.
             These keys also define permissible methods.
-    query: A Query object or callable returning one. Mustn't be None for GET-enabled endpoints
+    query_fn: A callable returning a Query object. Mustn't be None for GET-enabled endpoints.
     paginate_many: whether to return paginated results (default:True)
             The 'page' GET-parameter selects the page
     """
@@ -158,21 +158,18 @@ def endpoint(query, schemas=None, allow_delete=False, paginate_many=True):
     if allow_delete:
         methods.append('DELETE')
 
-    def make_query():
-        return query() if callable(query) else query
-
     def handle_get(instance_id=None):
         if instance_id is None:  # GET MANY
             assert 'GET' in schemas, "GET schema missing"
             schema = schemas['GET']
-            return filtered_results(make_query(), schema, paginate_many)
+            return filtered_results(query_fn(), schema, paginate_many)
         else:  # GET SINGLE
-            result = make_query().get(instance_id)
+            result = query_fn().get(instance_id)
             obj = serialize(result, schema)
             return obj
 
     def handle_delete(instance_id):
-        obj = make_query().get(instance_id)
+        obj = query_fn().get(instance_id)
         # since we don't know where this query came from, we need to detach obj
         # from its session before we can delete it. expunge does exactly this.
         inspect(obj).session.expunge(obj)

--- a/routes/documents.py
+++ b/routes/documents.py
@@ -52,7 +52,7 @@ class LectureDumpSchema(IdSchema):
 api_route('/api/lectures')(
 endpoint(
         schemas={'GET': LectureDumpSchema},
-        query=Lecture.query,
+        query_fn=lambda: Lecture.query,
         paginate_many=False)
 )
 
@@ -65,7 +65,7 @@ class ExaminantSchema(IdSchema):
 api_route('/api/examinants')(
 endpoint(
         schemas={'GET': ExaminantSchema},
-        query=Examinant.query,
+        query_fn=lambda: Examinant.query,
         paginate_many=False)
 )
 
@@ -82,7 +82,7 @@ def documents_query():
 api_route('/api/documents')(
 endpoint(
         schemas={'GET': DocumentDumpSchema},
-        query=documents_query)
+        query_fn=documents_query)
 )
 
 # aggregate values of unpaginated source data

--- a/routes/misc.py
+++ b/routes/misc.py
@@ -56,7 +56,7 @@ endpoint(
         schemas={
             'GET': OrderDumpSchema,
         },
-        query=Order.query.options(subqueryload('items.document.lectures'), subqueryload('items.document.examinants')))
+        query_fn=lambda: Order.query.options(subqueryload('items.document.lectures'), subqueryload('items.document.examinants')))
 ))
 
 
@@ -78,13 +78,13 @@ endpoint(
         schemas={
             'POST': OrderLoadSchema,
         },
-        query=None)
+        query_fn=None)
 ))
 
 api_route('/api/orders/<int:instance_id>', methods=['DELETE'])(
 login_required(
 endpoint(
-        query=Order.query,
+        query_fn=lambda: Order.query,
         allow_delete=True)
 ))
 
@@ -100,7 +100,7 @@ api_route('/api/deposits')(
 login_required(
 endpoint(
         schemas={'GET': DepositDumpSchema},
-        query=Deposit.query.options(subqueryload('lectures')))
+        query_fn=lambda: Deposit.query.options(subqueryload('lectures')))
 ))
 
 


### PR DESCRIPTION
Accessing the `query` property of a model before an app context is
pushed creates a session that is never rolled back or closed.