### PR TITLE
Print error message when creating a schema fails.

### DIFF
--- a/scripts/create_fsmi_models.py
+++ b/scripts/create_fsmi_models.py
@@ -29,9 +29,10 @@ def createSchema(name, bind=None):
     try:
         engine = sqla.get_engine(app, bind)
         engine.execute(CreateSchema(name))
-    except sqlalchemy.exc.ProgrammingError:
-        # schema already exists... do nothing
-        pass
+    except sqlalchemy.exc.ProgrammingError as e:
+        # schema probably already exists... do nothing
+        # but just in case it's another error, print it
+        print("Error creating schema {}, ignoring: {}".format(name, e))
 
 createSchema('public')
 createSchema('acl')

--- a/scripts/create_garfield_models.py
+++ b/scripts/create_garfield_models.py
@@ -32,9 +32,10 @@ def createSchema(name, bind=None):
     try:
         engine = sqla.get_engine(app, bind)
         engine.execute(CreateSchema(name))
-    except sqlalchemy.exc.ProgrammingError:
-        # schema already exists... do nothing
-        pass
+    except sqlalchemy.exc.ProgrammingError as e:
+        # schema probably already exists... do nothing
+        # but just in case it's another error, print it
+        print("Error creating schema {}, ignoring: {}".format(name, e))
 
 createSchema('public')
 createSchema('odie')


### PR DESCRIPTION
Silently ignoring the error makes troubleshooting more difficult. An
already existing schema is not the only error that can occur here
(e.g. permission errors).