### PR TITLE
Add @csrf.exempt to /api/documents_migration route

### DIFF
--- a/routes/documents.py
+++ b/routes/documents.py
@@ -158,6 +158,7 @@ def submit_document_external():
 # TODO: remove as soon as the migration is done
 @api_route('/api/documents_migration', methods=['POST'])
 @login_required
+@csrf.exempt
 def submit_document_migration():
     submit_documents(validate=True)
 


### PR DESCRIPTION
It's not testable locally otherwise.