### PR TITLE
Inform the client of specific status in the case of failed print jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/fsmi/odie?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Postgres backend for [odie](https://github.com/fsmi/odie-client).
+Postgres backend for [odie](https://github.com/fsmi/odie-client). See Odie in action at [our student council site](https://fsmi.uni-karlsruhe.de/odie).
 
 ## Setup ##
 

--- a/routes/accounting.py
+++ b/routes/accounting.py
@@ -12,7 +12,7 @@ from db.documents import Deposit, Document
 
 
 class ErroneousSaleLoadSchema(Schema):
-    amount = fields.Int(required=True, validate=lambda i: i > 0)
+    amount = fields.Int(required=True)
     cash_box = CashBoxField()
 
 # db.accounting does its own logging, so these endpoints don't


### PR DESCRIPTION
These can fail anywhere between printing, logging the exam sale and
logging the deposit, all of which need to be corrected for differently.