### PR TITLE
Security fix: Anonymous users must not leak submitter names

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Here's a small map of the api side of the project:
 * `db/*.py`  
   Declarative definition of the database tables we use. These include parts of the `garfield` database (into which we save all documents and their associated data) and parts of the `fsmi` database (which we query for user auth)
 * `api_utils.py`  
-  We're using Flask, Flask-login, SQLAlchemy, jsonquery and marshmallow. That means a lot of work is done for us and what's left of most API endpoints is mostly boilerplate for stringing all of this together. `api_utils.py` is where we abstract all of that away, too, so most API endpoints can be generated with a simple call to `api_utils.endpoint`. Also found there: grab bag of small utility functions that would only clutter routes.py.
+  We're using Flask, Flask-login, SQLAlchemy, jsonquery and marshmallow. That means a lot of work is done for us and what's left of most API endpoints is mostly boilerplate for stringing all of this together. `api_utils.py` is where we abstract all of that away, too, <s>so most API endpoints can be generated with a simple call to `api_utils.endpoint`</s>.  
+  _As it turned out years later, this idea was rather flawed: Allowing arbitrary queries by anonymous users (in particular it allows the `WHERE` clauses of `SELECT` queries to be arbitrarily set) can have unintended security consequences, because even columns that are not directly output [can be efficiently leaked](https://github.com/fsmi/odie-server/pull/168) by bruteforcing valid restrictions to these columns._  
+  Also found in `api_utils.py`: grab bag of small utility functions that would only clutter routes.py.
 * `barcode/barcode.py`  
   This is where barcode scanner support lives. It also handles putting barcodes on transcripts.
 * `admin/`

--- a/db/documents.py
+++ b/db/documents.py
@@ -104,6 +104,8 @@ folder_docs = sqla.Table('folder_docs',
         **config.documents_table_args)
 
 
+# Note that if you extend this enum, make sure to adjust the validation in routes/documents.py's documents_query()
+# accordingly.
 document_type = sqla.Enum('oral', 'written', 'oral reexam', 'mock exam', name='document_type', inherit_schema=True)
 
 

--- a/routes/documents.py
+++ b/routes/documents.py
@@ -10,6 +10,7 @@ import marshmallow
 from flask import request, send_file
 from marshmallow import Schema, fields
 from marshmallow.validate import OneOf
+from sqlalchemy import asc, desc
 from sqlalchemy.orm import subqueryload, undefer
 from sqlalchemy.orm.exc import NoResultFound
 from pytz import reference
@@ -70,18 +71,50 @@ endpoint(
 
 
 def documents_query():
-    q = Document.query.options(subqueryload('lectures'), subqueryload('examinants'))
-    filters = json.loads(request.args.get('filters', '{}'))
-    for id in filters.get('includes_lectures', []):
-        q = q.filter(Document.lectures.any(Lecture.id == id))
-    for id in filters.get('includes_examinants', []):
-        q = q.filter(Document.examinants.any(Examinant.id == id))
-    return q
+    query = Document.query.options(subqueryload('lectures'), subqueryload('examinants'))
+    param_filters = json.loads(request.args.get('filters', '{}'))
+    for id_ in param_filters.get('includes_lectures', []):
+        query = query.filter(Document.lectures.any(Lecture.id == id_))
+    for id_ in param_filters.get('includes_examinants', []):
+        query = query.filter(Document.examinants.any(Examinant.id == id_))
+
+    # From the documentselection view (which can be accessed anonymously) we usually get a GET parameter 'q' like this:
+    # {"operator":"order_by_desc","column":"date","value":{"operator":"and","value":[{"column":"document_type","operator":"in_","value":["written","oral","oral reexam","mock exam"]}]},"page":1}
+    # We need to parse and create the SQLAlchemy Query manually to avoid data leaks.
+    # (If we were instead using jsonquery, anonymous users were able to efficiently extract submitted_by names by
+    #  performing bisection with the submitted_by parameter and `like` operator.
+    #  See https://github.com/fsmi/odie-server/pull/168 for details.)
+    # For logged in users, we have set allow_insecure_authenticated=True on the /api/documents view to allow
+    # the `submitted_by` filter in the depositreturn view; logged in users have access to all the data anyway.
+    # Note that the `page` parameter is taken into account by endpoint()/filtered_results() in either case.
+    if not get_user():
+        param_q = json.loads(request.args.get('q', '{}'))
+        # While it looks ugly, we validate all parameters to ensure that the JSON structure is as expected and that only
+        # whitelisted values work.
+        if param_q.get('operator') in ('order_by_desc', 'order_by_asc') and \
+                param_q.get('column') in ('date', 'number_of_pages', 'validation_time'):
+            sort_fn = asc if param_q.get('operator') == 'order_by_asc' else desc
+            query = query.order_by(sort_fn(param_q['column']))
+
+        if isinstance(param_q.get('value'), dict) and \
+                param_q['value'].get('operator') == 'and' and \
+                isinstance(param_q['value'].get('value'), list) and \
+                len(param_q['value']['value']) == 1 and \
+                param_q['value']['value'][0].get('column') == 'document_type' and \
+                param_q['value']['value'][0].get('operator') == 'in_' and \
+                isinstance(param_q['value']['value'][0].get('value'), list) and \
+                all(value in ('written', 'oral', 'oral reexam', 'mock exam') for value in param_q['value']['value'][0]['value']):
+            query = query.filter(Document.document_type.in_(param_q['value']['value'][0]['value']))
+
+    return query
 
 api_route('/api/documents')(
 endpoint(
         schemas={'GET': DocumentDumpSchema},
-        query_fn=documents_query)
+        query_fn=documents_query,
+        # Allow insecure JSON queries for logged in users so that the `submitted_by` filter in the depositreturn.html
+        # view works.
+        allow_insecure_authenticated=True)
 )
 
 # aggregate values of unpaginated source data

--- a/routes/misc.py
+++ b/routes/misc.py
@@ -63,11 +63,13 @@ class OrderDumpSchema(IdSchema):
 
 api_route('/api/orders', methods=['GET'])(
 login_required(
-endpoint(
+    endpoint(
         schemas={
             'GET': OrderDumpSchema,
         },
-        query_fn=lambda: Order.query.options(subqueryload('items.document.lectures'), subqueryload('items.document.examinants')))
+        query_fn=lambda: Order.query.options(subqueryload('items.document.lectures'), subqueryload('items.document.examinants')),
+        allow_insecure_authenticated=True
+    )
 ))
 
 
@@ -111,7 +113,9 @@ class DepositDumpSchema(IdSchema):
 
 api_route('/api/deposits')(
 login_required(
-endpoint(
+    endpoint(
         schemas={'GET': DepositDumpSchema},
-        query_fn=lambda: Deposit.query.options(subqueryload('lectures')))
+        query_fn=lambda: Deposit.query.options(subqueryload('lectures')),
+        allow_insecure_authenticated=True
+    ),
 ))


### PR DESCRIPTION
The arbitrary jsonquery feature now needs to be explicitly enabled for
routes and is only ever allowed for authenticated users (because they
currently have access to all data anyway).

For the /api/documents route, we manually parse and validate the query
and build it from scratch for unauthenticated users, *without*
reverting to jsonquery.

Before, it was possible to efficiently extract submitted_by names by
applying restrictions in the form of `submitted_by LIKE '&lt;prefix&gt;%' to
the /api/documents route. A proof of concept exploit has been developed
using a bisection algorithm (interval halving) that extracts submitter
names of arbitrary protocols (even those that have not been validated
yet) in a matter of seconds.